### PR TITLE
Duplicate line in gen_taxrules on main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -174,6 +174,7 @@ void gen_taxrules(TaxPar &par)
 	trans->write_asc(data_fp);
       else 
 	trans->write(data_fp);
+	  
       delete trans;
     }
   


### PR DESCRIPTION
Line 177 & 178 had "delete trans;" duplicated causing an error of memory read (variable "trans" no longer exists after first delete).